### PR TITLE
39 can not generate a new fernet key if one is not already configured in the setting

### DIFF
--- a/rest_framework_simple_api_key/backends.py
+++ b/rest_framework_simple_api_key/backends.py
@@ -17,6 +17,7 @@ class APIKeyAuthentication(BaseBackend):
     model = APIKey
     key_parser = APIKeyParser()
     key_crypto = ApiKeyCrypto()
+    key_crypto.initialize()
 
     def get_key(self, request: HttpRequest) -> typing.Optional[str]:
         return self.key_parser.get(request)

--- a/rest_framework_simple_api_key/crypto.py
+++ b/rest_framework_simple_api_key/crypto.py
@@ -14,7 +14,11 @@ from rest_framework_simple_api_key.settings import package_settings
 
 
 class ApiKeyCrypto:
-    def __init__(self):
+    fernet = None
+    api_key_lifetime = None
+
+    # Always call this method after creating an instance of ApiKeyCrypto
+    def initialize(self):
         """
         We first start by making some checks on the fernet secret to ensure the value is not empty.
         """

--- a/rest_framework_simple_api_key/models.py
+++ b/rest_framework_simple_api_key/models.py
@@ -14,6 +14,7 @@ def _expiry_date():
 
 class AbstractAPIKeyManager(models.Manager):
     key_crypto = ApiKeyCrypto()
+    key_crypto.initialize()
 
     def get_api_key(self, pk: int | str):
         return self.get(revoked=False, pk=pk)

--- a/tests/test_api_key_ crypto.py
+++ b/tests/test_api_key_ crypto.py
@@ -6,6 +6,7 @@ from rest_framework_simple_api_key.crypto import ApiKeyCrypto
 class TestApiCrypto:
 
     key_crypto = ApiKeyCrypto()
+    key_crypto.initialize()
     payload = {"user_id": 1}
 
     def _encode_payload(self):


### PR DESCRIPTION
This fixes #39